### PR TITLE
add reference to sort drop down to data visualization

### DIFF
--- a/visualization/assets/script/dv1.js
+++ b/visualization/assets/script/dv1.js
@@ -230,6 +230,14 @@ function dv1(year,the_subject,sort) {
 				return d.images;
 			})
 		}
+		else if (sort == 8){
+			min = d3.min(filtered_data, function(d) { 
+				return d.notes;
+			})
+			max = d3.max(filtered_data, function(d) { 
+				return d.notes;
+			})
+		}
        	
        	x = d3.scaleLinear()
 			.domain([min,max])
@@ -1159,6 +1167,14 @@ function dv1(year,the_subject,sort) {
 					return d.images;
 				})
 			}
+			else if (the_sort == 8){
+				min = d3.min(filtered_data, function(d) { 
+					return d.notes;
+				})
+				max = d3.max(filtered_data, function(d) { 
+					return d.notes;
+				})
+			}
 
 			x = d3.scaleLinear()
 				.domain([min,max])
@@ -1193,6 +1209,9 @@ function dv1(year,the_subject,sort) {
 					}
 					else if (the_sort == 7){
 						return "translate(" + (x(d.images)+50) + "," + 0 + ")"
+					}
+					else if (the_sort == 8){ 
+						return "translate(" + (x(d.notes)+50) + "," + 0 + ")"
 					}
 				})
 		}

--- a/visualization/index.html
+++ b/visualization/index.html
@@ -109,6 +109,7 @@
 								<option name="incipit" value="5">tamaño de la introducción</option>
 								<!--<option name="issue" value="6">numero di avvisi</option>-->
 								<option name="images" value="7">número de imágenes</option>
+								<option name="reference" value="8">referencia</option>
 							</select>
 						</div>
 					</div>


### PR DESCRIPTION
## Description
This pull request adds a reference to the sorting dropdown within our data visualization component. The sorting dropdown provides users with the ability to easily sort and filter the data displayed in the visualization, enhancing the overall user experience and data exploration capabilities.

## Changes Made
- Added a reference to the sorting dropdown in the data visualization.
- Ensured the dropdown contains the new option `reference` in Spanish and its functional.
- Integrated sorting by reference functionality with the data visualization to allow users to sort data based on references.

## Demo video
https://github.com/wikicurricula-uy/wikicurricula-boilerplate/assets/95963770/74ce009a-f995-4d28-8c72-86862d412b54
