### PR TITLE
add view for missing curriculum topics

### DIFF
--- a/visualization/ghana.html
+++ b/visualization/ghana.html
@@ -27,6 +27,13 @@
 	    <meta property="og:image" content="https://itwiki-scuola-italiana.toolforge.org/assets/img/wikipedia-scuola-italiana_preview-twitter.png" />
 	    <meta name="twitter:site" content="Wikicurrícula Ghana" />
 	  	<meta property="og:url" content="https://wikicurricula-uy.github.io/" />
+		<style>
+			.missing{
+				color: red;
+				text-decoration: underline;
+				margin-left: 10px;
+			}
+		</style>
 	</head>
 	<body> 
 		<header>
@@ -36,6 +43,8 @@
 						<a href="" title="Wikicurrícula Gh" class="noselect">
 							Wikicurricula Ghana
 						</a>
+						<a class="missing" href="missing_wikipedia_articles.html?country=Q117&langCode=en&language=English">Missing Curriculum</a>
+
 					</h1>
 				</div>
 			</div>

--- a/visualization/index.html
+++ b/visualization/index.html
@@ -43,6 +43,13 @@
 	    <meta property="og:image" content="https://itwiki-scuola-italiana.toolforge.org/assets/img/wikipedia-scuola-italiana_preview-twitter.png" />
 	    <meta name="twitter:site" content="Wikicurrícula Uy" />
 	  	<meta property="og:url" content="https://wikicurricula-uy.github.io/" />
+		<style>
+			.missing{
+				color: red;
+				text-decoration: underline;
+				margin-left: 10px;
+			}
+		</style>
 	</head>
 	<body> 
 		<header>
@@ -52,7 +59,9 @@
 						<a href="" title="Wikicurrícula Uy" class="noselect">
 							Wikicurrícula Uy
 						</a>
+						<a class="missing" href="missing_wikipedia_articles.html?country=Q77&langCode=es&language=Spanish">Missing Curriculum</a>
 					</h1>
+
 				</div>
 			</div>
 			<!--<nav id="menu">

--- a/visualization/missing_wikipedia_articles.html
+++ b/visualization/missing_wikipedia_articles.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Curriculum Topics without Wikipedia Articles</title>
+</head>
+<body>
+    <h1>Curriculum Topics without Wikipedia Articles</h1>
+    <div id="content"></div>
+
+    <script>
+        // Define the SPARQL queries for Uruguay and Ghana curriculum topics
+        function getParams() {
+            const urlParams = new URLSearchParams(window.location.search);
+            return {country: urlParams.get('country'), langCode: urlParams.get('langCode'), language: urlParams.get('language')};
+        }
+
+        // Define the SPARQL query with a placeholder for the country code
+        function buildQuery(countryCode, language) {
+            return `
+            SELECT ?item ?itemLabel
+            WHERE {
+                ?item wdt:P31 wd:Q7075.
+                ?item wdt:P495 wd:${countryCode}.
+                MINUS { ?item schema:about ?article. }
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "${language}". }
+            }`;
+        }
+
+        // Function to make SPARQL queries to Wikidata and populate the HTML view
+        function fetchCurriculumTopics(query, language) {
+            const options = {
+      headers:new Headers({"Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",}),
+      mode: 'cors'
+    };
+            fetch(`https://query.wikidata.org/sparql?query=${encodeURIComponent(query)}&format=json`, options)
+                .then(response => {
+                    console.log({res:response.data})
+                    return response.json()})
+                .then(data => {
+                    console.log({data})
+                    const contentDiv = document.getElementById('content');
+                    const topics = data.results.bindings;
+                    if (topics.length === 0) {
+                        contentDiv.innerHTML += `<p>No topics found without articles in ${language} Wikipedia.</p>`;
+                    } else {
+                        contentDiv.innerHTML += `<h2>Topics without articles in ${language} Wikipedia:</h2>`;
+                        const ul = document.createElement('ul');
+                        topics.forEach(topic => {
+                            const label = topic.itemLabel.value;
+                            const itemUrl = `https://www.wikidata.org/wiki/${topic.item.value}`;
+                            ul.innerHTML += `<li><a href="${itemUrl}" target="_blank">${label}</a></li>`;
+                        });
+                        contentDiv.appendChild(ul);
+                    }
+                })
+                .catch(error => {
+                    console.error(error);
+                });
+        }
+
+        // Fetch and display Uruguay and Ghana curriculum topics
+        const {country, langCode, language} = getParams()
+        fetchCurriculumTopics(buildQuery(country, langCode), language);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Worked on adding new view for checking missing curriculum in there respective languages

https://github.com/wikicurricula-uy/wikicurricula-boilerplate/assets/95963770/f158e52d-2a12-4e61-888f-ce1a08a2b9d2

