### PR TITLE
Fixed Issue- #75 - x-Axis adpating the change according to subject

### DIFF
--- a/visualization/assets/script/dv1.js
+++ b/visualization/assets/script/dv1.js
@@ -944,16 +944,6 @@ function dv1(year, the_subject, sort) {
 		function update_subject(the_subject, the_sort) {
 			d3.select("#articles").remove();
 
-			d3.select("#datexAxis").remove();
-			d3.select("#xAxis").remove();
-
-			if (the_sort == 2) {
-				dateXAxis();
-			} else {
-				d3.select("#datexAxis").remove();
-				updateXScale(the_sort);
-			}
-
 			d3.selectAll("circle").transition().duration(300).attr("r", 0);
 
 			// load data
@@ -1391,6 +1381,17 @@ function dv1(year, the_subject, sort) {
 			//           		return "none"
 			//           	}
 			//           })
+
+
+			d3.select("#datexAxis").remove();
+			d3.select("#xAxis").remove();
+			if (the_sort == 2) {
+				dateXAxis();
+			} else {
+				d3.select("#datexAxis").remove();
+				updateXScale(the_sort);
+			}
+
 		}
 
 		function update_sort(the_subject, the_sort) {


### PR DESCRIPTION
Description :- 

Fixes #75 

This PR fix the problem of x-Axis, in issue 75, there were a slight problem, when the sort value along with subject value changed for the first time the x-Axis not adapting the changes , but if we change the subject for the seacond time it's updating the x-Axis. 

  I think,  actually the problem was, x-Asix updating function was called on the very top of the update_subject function, before the update of subject !! 
  I tried debug the code and finally came to know this could be a possible reason.
  So, this PR resolves this issue, after merging of this PR , the x-Axis get update according to the subject on first go.
  
Video before change :- 
  
  

https://github.com/wikicurricula-uy/wikicurricula-boilerplate/assets/97338915/d883eae0-dbaf-4973-9343-4f852814fb57

In this, it shown that once we update the sort value and subject than for the first time X-Axis not changing.

Video After Change :-

https://github.com/wikicurricula-uy/wikicurricula-boilerplate/assets/97338915/62efa5ed-ed49-4f87-a383-6ae27ab28634

Now the x-Axis updating according to subject.

Please review it @SannitaSSJ and @EneHacheCe , and let me know if any change possible , or if I mistake somewhere !!

